### PR TITLE
Add Cloud SQL Proxy with pgbouncer example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Backup files
+*.bak
+*.swp
+
+# Logs
+*.log
+
+# Environment files
+.env
+
+# Build outputs
+build/
+
+# Docker
+*.tar
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use the official Cloud SQL Proxy image to obtain the proxy binary
+FROM gcr.io/cloudsql-docker/gce-proxy:1.33.0 as proxy
+
+# Base runtime image
+FROM debian:bullseye-slim
+
+# Install pgbouncer
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pgbouncer \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the cloud_sql_proxy binary from the proxy image
+COPY --from=proxy /cloud_sql_proxy /usr/local/bin/cloud_sql_proxy
+
+# Copy configuration
+COPY pgbouncer.ini /etc/pgbouncer/pgbouncer.ini
+COPY userlist.txt /etc/pgbouncer/userlist.txt
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 5432
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # pgbouncerCloudProxy
+
+This repository contains a minimal setup for running [pgbouncer](https://www.pgbouncer.org/) in front of a Google Cloud SQL for PostgreSQL instance. The container bundles the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/connect-auth-proxy) alongside pgbouncer so that client applications only need to connect to the local pgbouncer port.
+
+## Directory structure
+
+- `Dockerfile` - builds an image with the Cloud SQL Auth Proxy and pgbouncer
+- `entrypoint.sh` - startup script that launches both the proxy and pgbouncer
+- `pgbouncer.ini` - pgbouncer configuration template
+- `userlist.txt` - list of users and password hashes for pgbouncer
+
+## Building the image
+
+```
+docker build -t my-pgbouncer-proxy .
+```
+
+## Running
+
+```
+docker run \
+  -e INSTANCE_CONNECTION_NAME="<PROJECT>:<REGION>:<INSTANCE>" \
+  -e DB_USER=postgres \
+  -e PROXY_PORT=5433 \
+  -p 5432:5432 \
+  my-pgbouncer-proxy
+```
+
+- `INSTANCE_CONNECTION_NAME` is the Cloud SQL instance connection name in `project:region:instance` format.
+- `PROXY_PORT` is the local port used for the Cloud SQL Proxy (default: `5433`). pgbouncer listens on port `5432` inside the container and forwards traffic to the proxy.
+
+You may customize `pgbouncer.ini` and `userlist.txt` to suit your needs.
+
+## Notes
+
+This example demonstrates the structure needed to run the Cloud SQL Proxy with pgbouncer. For production deployments ensure that the `userlist.txt` file contains strong password hashes and that sensitive data is stored securely (for example using Kubernetes secrets or other secret management systems).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+INSTANCE_CONNECTION_NAME=${INSTANCE_CONNECTION_NAME:?Cloud SQL instance connection name must be set}
+PROXY_PORT=${PROXY_PORT:-5433}
+
+# Start Cloud SQL Proxy
+cloud_sql_proxy -instances=${INSTANCE_CONNECTION_NAME}=tcp:${PROXY_PORT} &
+PROXY_PID=$!
+
+# Ensure proxy is terminated when this script exits
+trap 'kill -TERM ${PROXY_PID}' TERM INT
+
+# Update pgbouncer configuration to connect through the proxy
+sed -i "s/host=127.0.0.1 port=5432/host=127.0.0.1 port=${PROXY_PORT}/" /etc/pgbouncer/pgbouncer.ini
+
+# Launch pgbouncer
+exec pgbouncer /etc/pgbouncer/pgbouncer.ini

--- a/pgbouncer.ini
+++ b/pgbouncer.ini
@@ -1,0 +1,14 @@
+[databases]
+* = host=127.0.0.1 port=5432
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+unix_socket_dir = /var/run/pgbouncer
+auth_type = md5
+auth_file = /etc/pgbouncer/userlist.txt
+ignore_startup_parameters = extra_float_digits
+log_connections = yes
+log_disconnections = yes
+pool_mode = session
+server_reset_query = DISCARD ALL

--- a/userlist.txt
+++ b/userlist.txt
@@ -1,0 +1,1 @@
+"postgres" "md5changeme"


### PR DESCRIPTION
## Summary
- provide Dockerfile for cloud-sql-proxy with pgbouncer
- add container entrypoint script
- add default pgbouncer config and userlist
- document usage in README
- add .gitignore

## Testing
- `git status --short`